### PR TITLE
Feature/tao 2542 item creator entrypoint

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,30 +1,28 @@
 {
-    "name": "oat-sa/extension-itemqti-creator",
-    "description" : "Editor for QTI items",
-    "type" : "tao-extension",
-    "authors" : [
-        {
-        "name": "Open Assessment Technologies SA"
-        }
-    ],
-    "keywords" : [
-        "tao",
-        "computer-based-assessment"
-    ],
-    "homepage" : "http://www.taotesting.com",
-    "license" : [
-        "GPL-2.0"
-    ],
-    "extra" : {
-        "tao-extension-name" : "itemqtiCreator"
-    },
-    "minimum-stability" : "dev",
-    "require": {
-        "oat-sa/oatbox-extension-installer": "dev-master"
-    },
-    "autoload" : {
-        "psr-4" : {
-            "oat\\itemqtiCreator\\" : ""
-        }
-    } 
+  "name": "oat-sa/extension-itemqti-creator",
+  "description": "Editor for QTI items",
+  "type": "tao-extension",
+  "authors": [{
+    "name": "Open Assessment Technologies SA"
+  }],
+  "keywords": [
+    "tao",
+    "computer-based-assessment"
+  ],
+  "homepage": "http://www.taotesting.com",
+  "license": [
+    "GPL-2.0"
+  ],
+  "extra": {
+    "tao-extension-name": "itemqtiCreator"
+  },
+  "minimum-stability": "dev",
+  "require": {
+    "oat-sa/oatbox-extension-installer": "dev-master"
+  },
+  "autoload": {
+    "psr-4": {
+      "oat\\itemqtiCreator\\": ""
+    }
+  }
 }

--- a/controller/QtiCreator.php
+++ b/controller/QtiCreator.php
@@ -56,6 +56,8 @@ class QtiCreator extends \oat\taoQtiItem\controller\QtiCreator
 
         //load the creator config for this item
         $config = $this->getCreatorConfig($item);
+        $config->removePlugin('back');
+        $config->addPlugin('saveAndClose', 'itemqtiCreator/qtiCreator/plugins/menu/saveAndClose', 'menu');
 
         //the client config, with the controller to start
         $this->setData('client_config_url', $this->getClientConfigUrl(array(
@@ -65,6 +67,7 @@ class QtiCreator extends \oat\taoQtiItem\controller\QtiCreator
         )));
 
         $this->setData('config', $config->toArray());
+
         $this->setData('content-template', array('QtiCreator/index.tpl', 'taoQtiItem'));
 
         $this->setView('layout.tpl', 'itemqtiCreator');

--- a/controller/QtiCreator.php
+++ b/controller/QtiCreator.php
@@ -1,0 +1,72 @@
+<?php
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2016 (original work) Open Assessment Technologies SA
+ *
+ *
+ */
+
+namespace oat\itemqtiCreator\controller;
+
+use common_exception_Error;
+use core_kernel_classes_Resource;
+use tao_helpers_Request;
+use tao_helpers_Uri;
+
+/**
+ * Overrides the QtiCreator controller in order to provide a standalone mode of the item creator
+ *
+ * @author Bertrand Chevrier <bertrand@taotesting.com>
+ */
+class QtiCreator extends \oat\taoQtiItem\controller\QtiCreator
+{
+
+    /**
+     * Let's you open the Item Creator from the given URL :
+     * pcgAuth/QtiCreator/index?id=encoded_item_uri
+     *
+     */
+    public function index()
+    {
+        if(tao_helpers_Request::isAjax()){
+            throw new common_exception_Error("Wrong request mode, this is a plain document.");
+        }
+
+        if (!$this->hasRequestParameter('id')) {
+            throw new common_exception_Error('The item creator needs to be opened with an item, using the "id" parameter');
+        }
+
+        $item = new core_kernel_classes_Resource(tao_helpers_Uri::decode($this->getRequestParameter('id')));
+        if (!$item->exists()) {
+            throw new common_exception_Error('We\'re unable to find the selected item.');
+        }
+
+        //load the creator config for this item
+        $config = $this->getCreatorConfig($item);
+
+        //the client config, with the controller to start
+        $this->setData('client_config_url', $this->getClientConfigUrl(array(
+            'extension'  => 'taoQtiItem',
+            'module'     => 'QtiCreator',
+            'action'     => 'index'
+        )));
+
+        $this->setData('config', $config->toArray());
+        $this->setData('content-template', array('QtiCreator/index.tpl', 'taoQtiItem'));
+
+        $this->setView('layout.tpl', 'itemqtiCreator');
+    }
+}

--- a/manifest.php
+++ b/manifest.php
@@ -27,7 +27,7 @@ return array(
     'version' => '1.0.0',
 	'author' => 'Open Assessment Technologies SA',
 	'requires' => array(
-        'taoQtiItem' => '>=2.23.0'
+        'taoQtiItem' => '>=2.21.0'
     ),
     'managementRole' => 'http://www.tao.lu/Ontologies/generis.rdf#itemqtiCreatorManager',
     'acl' => array(

--- a/manifest.php
+++ b/manifest.php
@@ -1,23 +1,23 @@
 <?php
-/**  
+/**
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * as published by the Free Software Foundation; under version 2
  * of the License (non-upgradable).
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- * 
+ *
  * Copyright (c) 2016 (original work) Open Assessment Technologies SA;
- *               
- * 
- */               
+ *
+ *
+ */
 
 return array(
     'name' => 'itemqtiCreator',
@@ -39,16 +39,15 @@ return array(
     ),
     'routes' => array(
         '/itemqtiCreator' => 'oat\\itemqtiCreator\\controller'
-    ),    
-	'constants' => array(
-	    # views directory
-	    "DIR_VIEWS" => dirname(__FILE__).DIRECTORY_SEPARATOR."views".DIRECTORY_SEPARATOR,
-	    
-		#BASE URL (usually the domain root)
-		'BASE_URL' => ROOT_URL.'itemqtiCreator/',
-	    
-	    #BASE WWW required by JS
-	    'BASE_WWW' => ROOT_URL.'itemqtiCreator/views/'
-	),
+    ),
+    'constants' => array(
+        # views directory
+        "DIR_VIEWS" => dirname(__FILE__).DIRECTORY_SEPARATOR."views".DIRECTORY_SEPARATOR,
+
+        #BASE URL (usually the domain root)
+        'BASE_URL' => ROOT_URL.'itemqtiCreator/',
+
+        #BASE WWW required by JS
+        'BASE_WWW' => ROOT_URL.'itemqtiCreator/views/'
     )
 );

--- a/manifest.php
+++ b/manifest.php
@@ -27,7 +27,7 @@ return array(
     'version' => '1.0.0',
 	'author' => 'Open Assessment Technologies SA',
 	'requires' => array(
-        'taoQtiItem' => '>=2.21.0'
+        'taoQtiItem' => '>=2.27.0'
     ),
     'managementRole' => 'http://www.tao.lu/Ontologies/generis.rdf#itemqtiCreatorManager',
     'acl' => array(

--- a/views/js/qtiCreator/plugins/menu/saveAndClose.js
+++ b/views/js/qtiCreator/plugins/menu/saveAndClose.js
@@ -1,0 +1,104 @@
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2016 (original work) Open Assessment Technologies SA ;
+ */
+define([
+    'jquery',
+    'i18n',
+    'core/plugin',
+    'ui/hider',
+    'tpl!taoQtiItem/qtiCreator/plugins/button'
+], function($, __, pluginFactory, hider, buttonTpl){
+    'use strict';
+
+    return pluginFactory({
+        name : 'saveAndClose',
+
+        /**
+         * Initialize the plugin (called during runner's init)
+         */
+        init : function init(){
+            var self = this;
+            var itemCreator = this.getHost();
+
+            this.$element = $(buttonTpl({
+                icon: 'save',
+                title: __('Save and close the creator'),
+                text : __('Save & Close'),
+                cssClass: ''
+            })).on('click', function saveHandler(e){
+                e.preventDefault();
+                self.disable();
+                itemCreator.trigger('save');
+            });
+
+            this.hide();
+
+            itemCreator.on('saved', function(){
+                window.close();
+
+            });
+        },
+
+        render : function render(){
+
+            //attach the element to the menu area
+            var $container = this.getAreaBroker().getMenuArea();
+            $container.append(this.$element);
+            //this.disable();
+            this.show();
+
+        },
+
+        /**
+         * Called during the runner's destroy phase
+         */
+        destroy : function destroy (){
+            this.$element.remove();
+        },
+
+        /**
+         * Enable the button
+         */
+        enable : function enable (){
+            this.$element.removeProp('disabled')
+                         .removeClass('disabled');
+        },
+
+        /**
+         * Disable the button
+         */
+        disable : function disable (){
+            this.$element.prop('disabled', true)
+                         .addClass('disabled');
+        },
+
+        /**
+         * Show the button
+         */
+        show: function show(){
+            hider.show(this.$element);
+        },
+
+        /**
+         * Hide the button
+         */
+        hide: function hide(){
+            hider.hide(this.$element);
+        }
+    });
+});
+

--- a/views/js/qtiCreator/plugins/menu/saveAndClose.js
+++ b/views/js/qtiCreator/plugins/menu/saveAndClose.js
@@ -49,7 +49,6 @@ define([
 
             itemCreator.on('saved', function(){
                 window.close();
-
             });
         },
 

--- a/views/templates/layout.tpl
+++ b/views/templates/layout.tpl
@@ -14,7 +14,7 @@ $contentTemplate = Layout::getContentTemplate();
     <meta name="viewport" content="width=device-width, initial-scale=1">
 
     <title><?= Layout::getTitle() ?></title>
-    <link rel="shortcut icon" href="<?= Template::img('img/favicon.ico') ?>"/>
+    <link rel="shortcut icon" href="<?= Template::img('favicon.ico', 'tao') ?>"/>
     <link rel="stylesheet" href="<?= Template::css('preview.css','taoItems') ?>" />
     <?= tao_helpers_Scriptloader::render() ?>
     <?= Layout::getAmdLoader() ?>
@@ -23,10 +23,8 @@ $contentTemplate = Layout::getContentTemplate();
 </head>
 
 <body>
-    <div class="content-wrap">
-        <div id="feedback-box"></div>
-        <?php Template::inc($contentTemplate['path'], $contentTemplate['ext']); ?>
-    </div>
+    <?php Template::inc($contentTemplate['path'], $contentTemplate['ext']); ?>
+    <div id="feedback-box"></div>
     <div class="loading-bar"></div>
 </body>
 </html>

--- a/views/templates/layout.tpl
+++ b/views/templates/layout.tpl
@@ -1,0 +1,32 @@
+<?php
+use oat\tao\helpers\Template;
+use oat\tao\helpers\Layout;
+use oat\tao\model\theme\Theme;
+
+$contentTemplate = Layout::getContentTemplate();
+?>
+<!doctype html>
+<html class="no-js">
+<head>
+    <script src="<?= Template::js('lib/modernizr-2.8/modernizr.js', 'tao')?>"></script>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+
+    <title><?= Layout::getTitle() ?></title>
+    <link rel="shortcut icon" href="<?= Template::img('img/favicon.ico') ?>"/>
+    <link rel="stylesheet" href="<?= Template::css('preview.css','taoItems') ?>" />
+    <?= tao_helpers_Scriptloader::render() ?>
+    <?= Layout::getAmdLoader() ?>
+
+    <link rel="stylesheet" href="<?= Layout::getThemeStylesheet(Theme::CONTEXT_BACKOFFICE) ?>" />
+</head>
+
+<body>
+    <div class="content-wrap">
+        <div id="feedback-box"></div>
+        <?php Template::inc($contentTemplate['path'], $contentTemplate['ext']); ?>
+    </div>
+    <div class="loading-bar"></div>
+</body>
+</html>


### PR DESCRIPTION
Requires https://github.com/oat-sa/extension-tao-itemqti/pull/658

This provides an entry point to the item creator, using the URL `https://taopcg.localdomain/itemqtiCreator/QtiCreator/index?id=${itemURI}` (the item uri should be encoded using standard HTTP encoding `encodeURIComponent`)